### PR TITLE
check tvars are ids before using free-identifier=?

### DIFF
--- a/type-expander.hl.rkt
+++ b/type-expander.hl.rkt
@@ -1387,7 +1387,7 @@ definitions.
 @chunk[<define-type>
        (define-syntax new-define-type
          (syntax-parser
-           [(_ (~or name:id (name:id maybe-tvar …)) . whole-rest)
+           [(_ (~or name:id (name:id maybe-tvar:id …)) . whole-rest)
             #:with (tvar …) (if (attribute maybe-tvar) #'(maybe-tvar …) #'())
             #:with (tvar-not-ooo …) (filter (λ (tv) (not (free-identifier=? tv #'(… …))))
                                             (syntax->list #'(tvar …)))


### PR DESCRIPTION
This PR fixes an internal error like this:
```racket
(define-type (A 5) String)
;free-identifier=?: contract violation expected: identifier? given: #<syntax 5>`
```
And changes the error message to this, highlighting the `5` in the user program as wrong:
```racket
(define-type (A 5) String)
;define-type: expected identifier in: 5
```